### PR TITLE
Adjust padding-right to prevent contact-us weirdness

### DIFF
--- a/front-end/app/css/main.sass
+++ b/front-end/app/css/main.sass
@@ -35,9 +35,6 @@ body
       margin: 250px 25px 0px 150px
       line-height: 2.5
 
-    .our-greeting
-      margin-right: 50px
-
       .sign-off
         font-family: 'Pacifico'
         font-size: 1.2em
@@ -219,6 +216,16 @@ fieldset
   .introduction, .category, .contact-info
     margin-top: 20px
 
+  .body
+    padding-right: 5%
+
 @media (max-width: 768px)
   .page
     width: 90%
+
+  .body
+    padding-right: 5%
+
+@media (min-width: 769px)
+  .body
+    padding-right: 8%


### PR DESCRIPTION
Contact us was hitting the right side of the page in
un-good ways at specific widths. This eliminates the our
greeting right hand margin and adds a single page wide
one.
#### Before

![screen shot 2013-07-18 at 10 54 54 am](https://f.cloud.github.com/assets/1697198/819938/4e865c4e-efbb-11e2-91d1-21c99fab1761.png)
#### After

![screen shot 2013-07-18 at 10 55 05 am](https://f.cloud.github.com/assets/1697198/819945/6334101e-efbb-11e2-9c46-7d12f3d2318c.png)
